### PR TITLE
Feature add configuration for ssh keys

### DIFF
--- a/push-bits.sh
+++ b/push-bits.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
+source tpcds-env.sh
 
+# Check SSH Config settings from tpcds-env.sh
+
+echo "SSH_KEY env variable is set to $SSH_KEY"
+
+if [ "$SSH_KEY" = "False" ]; then
+  echo "SSH keyless access between nodes is assumed to be enabled. SSH config will be ignored."
+else
+  echo "SSH key required for node access. Using SSH config from tpcds-env.sh."
+fi
+
+# Push tpcds kits (tpcds-kit, impala-tpcds-kit) to each data node specified in dn.txt
 # TODO: make sure you have set up dn.txt with your DataNode hostnames, 1 per line
-set -e
 
 cat dn.txt | while read h
 do
-  scp -rp $HOME/tpcds-kit $h:$HOME
-  scp -rp $HOME/impala-tpcds-kit $h:$HOME
+  if [ "$SSH_KEY" = "False" ]; then
+    echo "scp -rp $HOME/tpcds-kit $h:$HOME"
+    scp -rp $HOME/tpcds-kit $h:$HOME
+    echo "scp -rp $HOME/impala-tpcds-kit $h:$HOME"
+    scp -rp $HOME/impala-tpcds-kit $h:$HOME
+  else
+    echo "scp -i $HOME/.ssh/$SSH_KEYNAME -rp $HOME/tpcds-kit $h:$HOME"
+    scp -i $HOME/.ssh/$SSH_KEYNAME -rp $HOME/tpcds-kit $h:$HOME
+    echo "scp -i $HOME/.ssh/$SSH_KEYNAME -rp $HOME/impala-tpcds-kit $h:$HOME"
+    scp -i $HOME/.ssh/$SSH_KEYNAME -rp $HOME/impala-tpcds-kit $h:$HOME
+  fi
 done

--- a/run-gen-facts.sh
+++ b/run-gen-facts.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
+source tpcds-env.sh
 
+# Check SSH Config settings from tpcds-env.sh
+
+echo "SSH_KEY env variable is set to $SSH_KEY"
+
+if [ "$SSH_KEY" = "False" ]; then
+  echo "SSH keyless access between nodes is assumed to be enabled. SSH config will be ignored."
+else
+  echo "SSH key required for node access. Using SSH config from tpcds-env.sh."
+fi
+
+# Run gen-facts.sh on each data node specified in dn.txt
 # TODO: make sure you have set up dn.txt with your DataNode hostnames, 1 per line
 
 cat dn.txt | while read h
-do 
-  ssh $h "cd $HOME/impala-tpcds-kit; ./gen-facts.sh" < /dev/null &
+do
+  if [ "$SSH_KEY" = "False" ]; then
+    echo "ssh $h 'cd $HOME/impala-tpcds-kit; ./gen-facts.sh' < /dev/null &"
+    ssh $h "cd $HOME/impala-tpcds-kit; ./gen-facts.sh" < /dev/null &
+  else
+    echo "ssh -i $HOME/.ssh/$SSH_KEYNAME $h 'cd $HOME/impala-tpcds-kit; ./gen-facts.sh' < /dev/null &"
+    ssh -i $HOME/.ssh/$SSH_KEYNAME $h "cd $HOME/impala-tpcds-kit; ./gen-facts.sh" < /dev/null &
+  fi
 done

--- a/set-nodenum.sh
+++ b/set-nodenum.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
+source tpcds-env.sh
 
+# Check SSH Config settings from tpcds-env.sh
+
+echo "SSH_KEY env variable is set to $SSH_KEY"
+
+if [ "$SSH_KEY" = "False" ]; then
+  echo "SSH keyless access between nodes is assumed to be enabled. SSH config will be ignored."
+else
+  echo "SSH key required for node access. Using SSH config from tpcds-env.sh."
+fi
+
+# Set node number for each data node specified in dn.txt
 # TODO: make sure you have set up dn.txt with your DataNode hostnames, 1 per line
 
 n=1
 cat dn.txt | while read h
-do 
+do
   echo "$h = $n"
-  ssh $h "echo export NODENUM=${n} > $HOME/impala-tpcds-kit/nodenum.sh" < /dev/null
+  if [ "$SSH_KEY" = "False" ]; then
+    echo "$h 'echo export NODENUM=${n} > $HOME/impala-tpcds-kit/nodenum.sh' < /dev/null"
+    ssh $h "echo export NODENUM=${n} > $HOME/impala-tpcds-kit/nodenum.sh" < /dev/null
+  else
+    echo "ssh -i $HOME/.ssh/$SSH_KEYNAME $h 'echo export NODENUM=${n} > $HOME/impala-tpcds-kit/nodenum.sh' < /dev/null"
+    ssh -i $HOME/.ssh/$SSH_KEYNAME $h "echo export NODENUM=${n} > $HOME/impala-tpcds-kit/nodenum.sh" < /dev/null
+  fi
   ((n=n+1))
 done

--- a/tpcds-env.sh
+++ b/tpcds-env.sh
@@ -1,3 +1,5 @@
+# DATA SCALING CONFIG (REQUIRED)
+
 # path to the tpcds-kit directory
 export TPCDS_ROOT=$HOME/tpcds-kit
 
@@ -17,3 +19,11 @@ export DSDGEN_TOTAL_THREADS=$((DSDGEN_NODES * DSDGEN_THREADS_PER_NODE))
 
 # the name for the tpcds database
 export TPCDS_DBNAME=tpcds_parquet
+
+
+# SSH ACCESS CONFIG (OPTIONAL)
+## Configure this section if you do not have keyless ssh access between nodes.
+## Default value is False since this code is based on the prerequisite that keyless ssh access exists between nodes.
+
+export SSH_KEY=False
+export SSH_KEYNAME=mykeyname


### PR DESCRIPTION
Enables users to additional configure tpcds-env.sh with an ssh keyname to use in the case where ssh keyless access is not possible between nodes.